### PR TITLE
fix(resume): properly order degree acronyms

### DIFF
--- a/src/routes/resume/+page.svelte
+++ b/src/routes/resume/+page.svelte
@@ -16,7 +16,7 @@
       <h3 class="text-black text-lg">Harvard University</h3>
       <div class="text-neutral-500 mb-0.5">2022 — 2023</div>
     </div>
-    <p class="byline">S.M. in Computer Science</p>
+    <p class="byline">M.S. in Computer Science</p>
   </div>
 
   <div class="mb-4">
@@ -24,7 +24,7 @@
       <h3 class="text-black text-lg">Harvard University</h3>
       <div class="text-neutral-500 mb-0.5">2019 — 2023</div>
     </div>
-    <p class="byline">A.B. in Computer Science and Mathematics</p>
+    <p class="byline">B.A. in Computer Science and Mathematics</p>
   </div>
 
   <p>Graduated magna cum laude, with highest honors in field.</p>


### PR DESCRIPTION
Maybe this was intentional... but I'm assuming it was not. Or maybe I am just unfamiliar with the A.B. and S.M. degrees.